### PR TITLE
Fixes glitched baby zombies.

### DIFF
--- a/.minecraft/kubejs/server_scripts/reclamation.js
+++ b/.minecraft/kubejs/server_scripts/reclamation.js
@@ -1,11 +1,16 @@
 EntityEvents.spawned(event => {
-  const entity = event.entity;
+  let entity = event.entity;
 
-  if (entity.type == 'minecraft:chicken') {
-    const passengers = entity.passengers;
-    if (passengers && passengers.length > 0) {
-      event.cancel()
-    }
+  // Check if we are spawning a chicken with passengers
+  if (entity.type == 'minecraft:chicken' && !entity.passengers.isEmpty()) {
+
+    // detach all passengers
+    entity.passengers.forEach(p => {
+      p.stopRiding();
+    });
+
+    // cancel the spawning event for the chicken
+    event.cancel();
   }
 })
 


### PR DESCRIPTION
This pull request addresses issue #77.   The spawn event now requests the passenger to stop riding before canceling the chicken spawn event.    

Tested with the following command in game: 

```/summon chicken ~ ~ ~ {Passengers:[{id:zombie,IsBaby:1}]}```
