### PR TITLE
Added recipes for logs and saplings from Enchanted mod

### DIFF
--- a/.minecraft/kubejs/server_scripts/mystical_agriculture_recipes.js
+++ b/.minecraft/kubejs/server_scripts/mystical_agriculture_recipes.js
@@ -298,6 +298,69 @@ ServerEvents.recipes(event => {
         G: 'embers:ember_crystal'
     })
 
+    //Alder log
+    event.shaped('12x enchanted:alder_log', [
+        '   ',
+        'WFW',
+        '   '
+    ], {
+        W: 'mysticalagriculture:wood_essence',
+        F: 'mysticalagriculture:fertilized_essence'
+    })
+
+    //Hawthorn log
+    event.shaped('12x enchanted:hawthorn_log', [
+        ' W ',
+        ' F ',
+        ' W '
+    ], {
+        W: 'mysticalagriculture:wood_essence',
+        F: 'mysticalagriculture:fertilized_essence'
+    })
+
+    //Rowan log
+    event.shaped('12x enchanted:rowan_log', [
+        '  W',
+        ' F ',
+        'W  '
+    ], {
+        W: 'mysticalagriculture:wood_essence',
+        F: 'mysticalagriculture:fertilized_essence'
+    })
+
+    //Alder sapling
+    event.shaped('4x enchanted:alder_sapling', [
+        ' F ',
+        'WNW',
+        ' F '
+    ], {
+        W: 'mysticalagriculture:wood_essence',
+        F: 'mysticalagriculture:fertilized_essence',
+        N: 'mysticalagriculture:nature_essence'
+    })
+
+    //Hawthorn sapling
+    event.shaped('4x enchanted:hawthorn_sapling', [
+        ' W ',
+        'FNF',
+        ' W '
+    ], {
+        W: 'mysticalagriculture:wood_essence',
+        F: 'mysticalagriculture:fertilized_essence',
+        N: 'mysticalagriculture:nature_essence'
+    })
+
+    //Rowan sapling
+    event.shaped('4x enchanted:rowan_sapling', [
+        '  W',
+        'FNF',
+        'W  '
+    ], {
+        W: 'mysticalagriculture:wood_essence',
+        F: 'mysticalagriculture:fertilized_essence',
+        N: 'mysticalagriculture:nature_essence'
+    })
+
     //remove infusion
     event.remove({input: '#mysticalagriculture:infusion_crystals'})
     event.remove({id: 'mysticalagriculture:prudentium_essence_uncraft'})

--- a/.minecraft/kubejs/server_scripts/mystical_agriculture_recipes.js
+++ b/.minecraft/kubejs/server_scripts/mystical_agriculture_recipes.js
@@ -298,69 +298,6 @@ ServerEvents.recipes(event => {
         G: 'embers:ember_crystal'
     })
 
-    //Alder log
-    event.shaped('12x enchanted:alder_log', [
-        '   ',
-        'WFW',
-        '   '
-    ], {
-        W: 'mysticalagriculture:wood_essence',
-        F: 'mysticalagriculture:fertilized_essence'
-    })
-
-    //Hawthorn log
-    event.shaped('12x enchanted:hawthorn_log', [
-        ' W ',
-        ' F ',
-        ' W '
-    ], {
-        W: 'mysticalagriculture:wood_essence',
-        F: 'mysticalagriculture:fertilized_essence'
-    })
-
-    //Rowan log
-    event.shaped('12x enchanted:rowan_log', [
-        '  W',
-        ' F ',
-        'W  '
-    ], {
-        W: 'mysticalagriculture:wood_essence',
-        F: 'mysticalagriculture:fertilized_essence'
-    })
-
-    //Alder sapling
-    event.shaped('4x enchanted:alder_sapling', [
-        ' F ',
-        'WNW',
-        ' F '
-    ], {
-        W: 'mysticalagriculture:wood_essence',
-        F: 'mysticalagriculture:fertilized_essence',
-        N: 'mysticalagriculture:nature_essence'
-    })
-
-    //Hawthorn sapling
-    event.shaped('4x enchanted:hawthorn_sapling', [
-        ' W ',
-        'FNF',
-        ' W '
-    ], {
-        W: 'mysticalagriculture:wood_essence',
-        F: 'mysticalagriculture:fertilized_essence',
-        N: 'mysticalagriculture:nature_essence'
-    })
-
-    //Rowan sapling
-    event.shaped('4x enchanted:rowan_sapling', [
-        '  W',
-        'FNF',
-        'W  '
-    ], {
-        W: 'mysticalagriculture:wood_essence',
-        F: 'mysticalagriculture:fertilized_essence',
-        N: 'mysticalagriculture:nature_essence'
-    })
-
     //remove infusion
     event.remove({input: '#mysticalagriculture:infusion_crystals'})
     event.remove({id: 'mysticalagriculture:prudentium_essence_uncraft'})

--- a/.minecraft/kubejs/server_scripts/reclamation_recipes.js
+++ b/.minecraft/kubejs/server_scripts/reclamation_recipes.js
@@ -1239,6 +1239,69 @@ ServerEvents.recipes(event => {
         G: 'create:creative_motor'
     })
 
+    //Alder log
+    event.shaped('12x enchanted:alder_log', [
+        '   ',
+        'WFW',
+        '   '
+    ], {
+        W: 'mysticalagriculture:wood_essence',
+        F: 'mysticalagriculture:fertilized_essence'
+    })
+
+    //Hawthorn log
+    event.shaped('12x enchanted:hawthorn_log', [
+        ' W ',
+        ' F ',
+        ' W '
+    ], {
+        W: 'mysticalagriculture:wood_essence',
+        F: 'mysticalagriculture:fertilized_essence'
+    })
+
+    //Rowan log
+    event.shaped('12x enchanted:rowan_log', [
+        '  W',
+        ' F ',
+        'W  '
+    ], {
+        W: 'mysticalagriculture:wood_essence',
+        F: 'mysticalagriculture:fertilized_essence'
+    })
+
+    //Alder sapling
+    event.shaped('4x enchanted:alder_sapling', [
+        ' F ',
+        'WNW',
+        ' F '
+    ], {
+        W: 'mysticalagriculture:wood_essence',
+        F: 'mysticalagriculture:fertilized_essence',
+        N: 'mysticalagriculture:nature_essence'
+    })
+
+    //Hawthorn sapling
+    event.shaped('4x enchanted:hawthorn_sapling', [
+        ' W ',
+        'FNF',
+        ' W '
+    ], {
+        W: 'mysticalagriculture:wood_essence',
+        F: 'mysticalagriculture:fertilized_essence',
+        N: 'mysticalagriculture:nature_essence'
+    })
+
+    //Rowan sapling
+    event.shaped('4x enchanted:rowan_sapling', [
+        '  W',
+        'FNF',
+        'W  '
+    ], {
+        W: 'mysticalagriculture:wood_essence',
+        F: 'mysticalagriculture:fertilized_essence',
+        N: 'mysticalagriculture:nature_essence'
+    })
+
     event.shaped('minecraft:lantern', [
         'CCC',
         'CTC',


### PR DESCRIPTION
Added recipes for wood logs and saplings from Enchanted mod - suggestion #215. For balance reasons I reduced amount of craftable items - logs will be the same amount as Nether logs, and saplings - only half from standard amount. For logs additionally required 1 fertilizer essence, for saplings - 2  fertilizer essences.
Please, review the recipes and edit them if needed.
<img width="528" height="324" alt="image" src="https://github.com/user-attachments/assets/af176330-1887-421d-a667-5cf36a8a721a" />
<img width="517" height="319" alt="image" src="https://github.com/user-attachments/assets/a1c59735-0846-4a65-ad30-0cf44dc9fbfa" />
<img width="521" height="312" alt="image" src="https://github.com/user-attachments/assets/64e44a14-a246-446e-a997-121352759fb7" />
<img width="521" height="330" alt="image" src="https://github.com/user-attachments/assets/73a326fb-4dec-4728-817a-49c5fc79a68d" />
<img width="520" height="319" alt="image" src="https://github.com/user-attachments/assets/777ed610-c382-4a2b-9d23-df2d19f959dc" />
<img width="522" height="333" alt="image" src="https://github.com/user-attachments/assets/b7b7d43c-76e5-4c1e-80d1-df1d7f9e6b52" />
