### PR TITLE
Added alternative recipes for candle holders and chandeliers from Macaw's Lights and Lamps

### DIFF
--- a/.minecraft/kubejs/server_scripts/reclamation_recipes.js
+++ b/.minecraft/kubejs/server_scripts/reclamation_recipes.js
@@ -1247,6 +1247,217 @@ ServerEvents.recipes(event => {
         T: 'minecraft:torch',
         C: 'create:copper_nugget'
     })
+    
+    //Macaw's Lights and Lamps recipes using Beeswax instead of vanilla Honeycomb
+    event.shaped('mcwlights:golden_low_candle_holder', [
+        ' S ',
+        ' W ',
+        ' G '
+    ], {
+        S: 'minecraft:string',
+        W: 'complicated_bees:beeswax',
+        G: 'minecraft:gold_ingot',
+    })
+
+    event.shaped('mcwlights:copper_low_candle_holder', [
+        ' S ',
+        ' W ',
+        ' C '
+    ], {
+        S: 'minecraft:string',
+        W: 'complicated_bees:beeswax',
+        C: 'minecraft:copper_ingot',
+    })
+
+    event.shaped('mcwlights:iron_low_candle_holder', [
+        ' S ',
+        ' W ',
+        ' I '
+    ], {
+        S: 'minecraft:string',
+        W: 'complicated_bees:beeswax',
+        I: 'minecraft:iron_ingot',
+    })
+
+    event.shaped('2x mcwlights:golden_candle_holder', [
+        ' S ',
+        'GWG',
+        ' G '
+    ], {
+        S: 'minecraft:string',
+        W: 'complicated_bees:beeswax',
+        G: 'minecraft:gold_ingot',
+    })
+
+    event.shaped('2x mcwlights:copper_candle_holder', [
+        ' S ',
+        'CWC',
+        ' C '
+    ], {
+        S: 'minecraft:string',
+        W: 'complicated_bees:beeswax',
+        C: 'minecraft:copper_ingot',
+    })
+
+    event.shaped('2x mcwlights:iron_candle_holder', [
+        ' S ',
+        'IWI',
+        ' I '
+    ], {
+        S: 'minecraft:string',
+        W: 'complicated_bees:beeswax',
+        I: 'minecraft:iron_ingot',
+    })
+
+    event.shaped('mcwlights:golden_wall_candle_holder', [
+        'S  ',
+        'WGG',
+        '   '
+    ], {
+        S: 'minecraft:string',
+        W: 'complicated_bees:beeswax',
+        G: 'minecraft:gold_ingot',
+    })
+
+    event.shaped('mcwlights:copper_wall_candle_holder', [
+        'S  ',
+        'WCC',
+        '   '
+    ], {
+        S: 'minecraft:string',
+        W: 'complicated_bees:beeswax',
+        C: 'minecraft:copper_ingot',
+    })
+
+    event.shaped('mcwlights:iron_wall_candle_holder', [
+        'S  ',
+        'WII',
+        '   '
+    ], {
+        S: 'minecraft:string',
+        W: 'complicated_bees:beeswax',
+        I: 'minecraft:iron_ingot',
+    })
+
+    event.shaped('mcwlights:golden_double_candle_holder', [
+        'S S',
+        'WGW',
+        ' G '
+    ], {
+        S: 'minecraft:string',
+        W: 'complicated_bees:beeswax',
+        G: 'minecraft:gold_ingot',
+    })
+
+    event.shaped('mcwlights:copper_double_candle_holder', [
+        'S S',
+        'WCW',
+        ' C '
+    ], {
+        S: 'minecraft:string',
+        W: 'complicated_bees:beeswax',
+        C: 'minecraft:copper_ingot',
+    })
+
+    event.shaped('mcwlights:iron_double_candle_holder', [
+        'S S',
+        'WIW',
+        ' I '
+    ], {
+        S: 'minecraft:string',
+        W: 'complicated_bees:beeswax',
+        I: 'minecraft:iron_ingot',
+    })
+
+    event.shaped('mcwlights:golden_triple_candle_holder', [
+        'SSS',
+        'WWW',
+        ' G '
+    ], {
+        S: 'minecraft:string',
+        W: 'complicated_bees:beeswax',
+        G: 'minecraft:gold_ingot',
+    })
+
+    event.shaped('mcwlights:copper_triple_candle_holder', [
+        'SSS',
+        'WWW',
+        ' C '
+    ], {
+        S: 'minecraft:string',
+        W: 'complicated_bees:beeswax',
+        C: 'minecraft:copper_ingot',
+    })
+
+    event.shaped('mcwlights:iron_triple_candle_holder', [
+        'SSS',
+        'WWW',
+        ' I '
+    ], {
+        S: 'minecraft:string',
+        W: 'complicated_bees:beeswax',
+        I: 'minecraft:iron_ingot',
+    })
+
+    event.shaped('mcwlights:golden_small_chandelier', [
+        'SGS',
+        'WGW',
+        '   '
+    ], {
+        S: 'minecraft:string',
+        W: 'complicated_bees:beeswax',
+        G: 'minecraft:gold_ingot',
+    })
+
+    event.shaped('mcwlights:copper_small_chandelier', [
+        'SCS',
+        'WCW',
+        '   '
+    ], {
+        S: 'minecraft:string',
+        W: 'complicated_bees:beeswax',
+        C: 'minecraft:copper_ingot',
+    })
+
+    event.shaped('mcwlights:iron_small_chandelier', [
+        'SIS',
+        'WIW',
+        '   '
+    ], {
+        S: 'minecraft:string',
+        W: 'complicated_bees:beeswax',
+        I: 'minecraft:iron_ingot',
+    })
+
+    event.shaped('mcwlights:golden_chandelier', [
+        'SGS',
+        'WGW',
+        'G G'
+    ], {
+        S: 'minecraft:string',
+        W: 'complicated_bees:beeswax',
+        G: 'minecraft:gold_ingot',
+    })
+
+    event.shaped('mcwlights:copper_chandelier', [
+        'SCS',
+        'WCW',
+        'C C'
+    ], {
+        S: 'minecraft:string',
+        W: 'complicated_bees:beeswax',
+        C: 'minecraft:copper_ingot',
+    })
+
+    event.shaped('mcwlights:iron_chandelier', [
+        'SIS',
+        'WIW',
+        'I I'
+    ], {
+        S: 'minecraft:string',
+        W: 'complicated_bees:beeswax',
+        I: 'minecraft:iron_ingot',
+    })
 
     event.custom({
         "type": "advanced_ae:reaction",


### PR DESCRIPTION
At this moment it is impossible to create some blocks from Macaw's Lights and Lamps until the world restoration? because of vanilla Honeycomb item using in the original recipe.
Also it is weird that we can create simple candles using Beeswax from Complicated Bees, but cannot make candles on holder at the same time. So i added new recipes for Candle Holders and Chandeliers using Beeswax instead of Honeycomb - on the same manner as it works for vanilla candles now.

Candle (as it works on 1.7.0 version)
<img width="515" height="675" alt="image" src="https://github.com/user-attachments/assets/2ebfc1ed-fef9-432e-8de4-6600dd545f75" />

Holders and Chandeliers with new recipe (some examples):
<img width="519" height="518" alt="image" src="https://github.com/user-attachments/assets/e136ecb3-b300-4604-8943-e3f32ac464ec" />
<img width="518" height="527" alt="image" src="https://github.com/user-attachments/assets/46008eec-8fc9-4c4a-8256-f093b8cba3ef" />
<img width="518" height="534" alt="image" src="https://github.com/user-attachments/assets/767d110f-202c-4a3b-9125-de00b3beec75" />
<img width="518" height="571" alt="image" src="https://github.com/user-attachments/assets/bbb939ac-09b9-45f7-9b08-cae4c78330b0" />
